### PR TITLE
Feat implementation manager

### DIFF
--- a/contracts/factory/Factory.sol
+++ b/contracts/factory/Factory.sol
@@ -2,72 +2,46 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/proxy/Clones.sol";
-import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 /// @title Factory Contract for creating clones of a given implementation
 /// @dev Extends AccessControl, Initializable, and ReentrancyGuard from OpenZeppelin
-abstract contract Factory is AccessControl, Initializable, ReentrancyGuard {
-    bytes32 public constant UPDATER_ROLE = keccak256("UPDATER_ROLE");
-
-    /// Address of the implementation contract
-    address public implementation;
-
-    /// Errors
-    error InvalidImplementationAddress();
+abstract contract Factory is Initializable, ReentrancyGuard {
+    /// Eimitted if a clone fails to initialize
     error InitializationFailed();
-
-    /// Emitted when a new implementation address is stored
-    event ImplementationStored(address indexed implementation);
 
     /// Emitted when a new clone is created
     event CloneCreated(address indexed cloneAddress, address indexed implementation, bytes32 indexed salt);
-
-    /// @notice Initializes the contract with the given implementation address
-    /// @param _implementation The address of the implementation contract
-    /// @dev Sets up roles and sets the implementation address
-    constructor(address _implementation){
-        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        _grantRole(UPDATER_ROLE, msg.sender);
-        _setImplementation(_implementation);
-    }
-
-    /// @notice Updates the address of the implementation contract
-    /// @param newImplementation The address of the new implementation contract
-    /// @dev Requires UPDATER_ROLE; emits ImplementationStored event
-    function updateImplementation(address newImplementation) public onlyRole(UPDATER_ROLE) {
-        _setImplementation(newImplementation);
-    }
-
-    /// @notice Internal function to set the implementation address
-    /// @param newImplementation The address of the new implementation contract
-    /// @dev Validates the new address and updates state; emits ImplementationStored event
-    function _setImplementation(address newImplementation) internal {
-        if (newImplementation == address(0)) revert InvalidImplementationAddress();
-
-        implementation = newImplementation;
-        emit ImplementationStored(newImplementation);
-    }
+    event CloneInitialized(address indexed cloneAddress, bytes initData);
 
     /// @notice Clones the implementation contract using a deterministic address
     /// @param salt The salt value used for predictable cloning
     /// @return The address of the newly created clone
     /// @dev Uses OpenZeppelin's Clones library
-    function clone(bytes32 salt) public returns (address) {
-        address _clone = Clones.cloneDeterministic(implementation, salt);
-        emit CloneCreated(_clone, implementation, salt);
-        return _clone;
+    function clone(bytes32 salt, address _immplementation) public virtual returns (address) {
+        return _clone(salt, _immplementation);
+    }
+
+    function _clone(bytes32 salt, address _implementation) internal returns (address) {
+        address output = Clones.cloneDeterministic(_implementation, salt);
+        emit CloneCreated(output, _implementation, salt);
+        return output;
     }
 
     /// @notice Initializes a cloned contract with provided data
     /// @param cloneAddress The address of the cloned contract
     /// @param initData The initialization data to be sent to the cloned contract
     /// @dev Calls the cloned contract with provided data; requires success
-    function init(address cloneAddress, bytes calldata initData) public {
-        (bool success, ) = cloneAddress.call(initData);
+    function initClone(address cloneAddress, bytes calldata initData) public payable virtual {
+        _initClone(cloneAddress, initData);
+    }
+
+    function _initClone(address cloneAddress, bytes calldata initData) internal {
+        (bool success, ) = cloneAddress.call{ value: msg.value }(initData);
 
         if (!success) revert InitializationFailed();
+        emit CloneInitialized(cloneAddress, initData);
     }
 
     /// @notice Clones and initializes a new contract in one transaction
@@ -75,21 +49,29 @@ abstract contract Factory is AccessControl, Initializable, ReentrancyGuard {
     /// @param initData The initialization data for the new clone
     /// @return The address of the newly created and initialized clone
     /// @dev Combines the clone and init functions for convenience
-    function cloneAndInitialize(bytes32 salt, bytes calldata initData) public returns (address) {
-        address _clone = this.clone(salt);
-        this.init(_clone, initData);
-        return _clone;
+    function cloneAndInitialize(
+        bytes32 salt,
+        address implementation,
+        bytes calldata initData
+    ) public payable virtual returns (address) {
+        return _cloneAndInitialize(salt, implementation, initData);
+    }
+
+    function _cloneAndInitialize(
+        bytes32 salt,
+        address implementation,
+        bytes calldata initData
+    ) private returns (address) {
+        address output = clone(salt, implementation);
+        initClone(output, initData);
+        return output;
     }
 
     /// @notice Predicts the address of a clone created with a specific implementation and salt
     /// @param salt The salt value to be used in the deterministic cloning process
     /// @return The predicted address of the new clone contract
     /// @dev Utilizes the keccak256 hash of the concatenation of a prefix, the factory contract address, salt, and the implementation bytecode for prediction
-    function predictCloneAddress(bytes32 salt) public view returns (address) {
-        bytes memory bytecode = abi.encodePacked(type(Clones).creationCode, abi.encode(implementation));
-
-        bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), address(this), salt, keccak256(bytecode)));
-
-        return address(uint160(uint256(hash)));
+    function predictCloneAddress(bytes32 salt, address implementation) public view returns (address) {
+        return Clones.predictDeterministicAddress(implementation, salt, address(this));
     }
 }

--- a/contracts/factory/ImplementationManager.sol
+++ b/contracts/factory/ImplementationManager.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import "./Factory.sol";
+
+/// @title Factory Contract for creating clones of a given implementation
+/// @dev Extends AccessControl, Initializable, and ReentrancyGuard from OpenZeppelin
+contract ImplementationManager is AccessControl, Factory {
+    bytes32 public constant UPDATER_ROLE = keccak256("UPDATER_ROLE");
+
+    // Custom error messages
+    error TypeAlreadyExists();
+    error TypeDoesNotExist();
+    error NotAuthorized();
+    error VersionExists();
+    error CommitExists();
+
+    struct Implementation {
+        address implementation;
+        uint16 version;
+        bytes32 commitHash;
+    }
+
+    struct ContractType {
+        bytes32 typeHash;
+        uint16 latestVersion;
+    }
+
+    mapping(bytes32 => ContractType) public contractTypes;
+    mapping(bytes32 => Implementation[]) public implementations;
+
+    //track versions and committs for no clashes
+    mapping(bytes32 => mapping(uint16 => bool)) public versions;
+    mapping(bytes32 => mapping(bytes32 => bool)) public commits;
+
+    constructor() {
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(UPDATER_ROLE, msg.sender);
+    }
+
+    modifier onlyUpdater() {
+        if (!hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) revert NotAuthorized();
+        _;
+    }
+
+    function getTypeHash(string memory typeName) public pure returns (bytes32) {
+        return keccak256(abi.encode(typeName));
+    }
+
+    function addContractType(string memory typeName) external onlyUpdater {
+        bytes32 typeHash = getTypeHash(typeName);
+        if (contractTypes[typeHash].typeHash == bytes32(0)) revert TypeAlreadyExists();
+
+        contractTypes[typeHash] = ContractType(typeHash, 0);
+    }
+
+    function addImplementation(
+        string memory typeName,
+        address implementation,
+        uint16 version,
+        bytes32 commitHash
+    ) external onlyUpdater {
+        bytes32 typeHash = getTypeHash(typeName);
+        ContractType storage contractType = contractTypes[typeHash];
+
+        if (contractType.typeHash == bytes32(0)) revert TypeDoesNotExist();
+        if (versions[typeHash][version]) revert VersionExists();
+        if (commits[typeHash][commitHash]) revert CommitExists();
+
+        implementations[typeHash].push(Implementation(implementation, version, commitHash));
+        contractType.latestVersion = version;
+
+        // Marking the version and commit hash as used for this contract type
+        versions[typeHash][version] = true;
+        commits[typeHash][commitHash] = true;
+    }
+
+    function getLatestImplementation(string memory typeName) external view returns (address, uint16, bytes32) {
+        bytes32 typeHash = getTypeHash(typeName);
+        Implementation[] storage impls = implementations[typeHash];
+        uint256 latestIndex = impls.length - 1;
+        return (impls[latestIndex].implementation, impls[latestIndex].version, impls[latestIndex].commitHash);
+    }
+
+    function getImplementationByVersion(string memory typeName, uint16 version) external view returns (address) {
+        bytes32 typeHash = getTypeHash(typeName);
+        Implementation[] storage impls = implementations[typeHash];
+
+        for (uint i = 0; i < impls.length; i++) {
+            if (impls[i].version == version) {
+                return impls[i].implementation;
+            }
+        }
+
+        revert TypeDoesNotExist(); // No matching implementation found for the given version
+    }
+}

--- a/contracts/factory/Mock/MockFactory.sol
+++ b/contracts/factory/Mock/MockFactory.sol
@@ -6,12 +6,5 @@ import "../Factory.sol";
 /// @title MockFactory
 /// @notice A mock implementation of the Factory contract
 contract MockFactory is Factory {
-    string public MOCK_NAME;
 
-    /// @dev Initializes the MockFactory contract
-    /// @param _name The name of the mock factory
-    /// @param _implementation The address of the implementation contract
-    constructor(string memory _name, address _implementation) Factory(_implementation) {
-        MOCK_NAME = _name;
-    }
 }

--- a/contracts/factory/Mock/MockToken.sol
+++ b/contracts/factory/Mock/MockToken.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+contract MockToken is Initializable, ERC20Upgradeable {
+    function initialize(string memory name, string memory symbol) public initializer {
+        __ERC20_init(name, symbol);
+        _mint(msg.sender, 1000 * 10 ** decimals()); // Initial supply
+    }
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+
+    function burn(address from, uint256 amount) public {
+        _burn(from, amount);
+    }
+}

--- a/tests/ImplementationManager/ImplementationManager.fixture.ts
+++ b/tests/ImplementationManager/ImplementationManager.fixture.ts
@@ -1,0 +1,13 @@
+// ImplementationManager.fixture.ts
+import { ethers } from "hardhat";
+import type { ImplementationManager } from "../../types";
+import type { ImplementationManager__factory } from "../../types";
+
+export async function deployImplementationManagerFixture() {
+    const [deployer] = await ethers.getSigners();
+
+    const ImplementationManagerFactory = (await ethers.getContractFactory("ImplementationManager", deployer)) as ImplementationManager__factory;
+    const implementationManager = await ImplementationManagerFactory.deploy() as ImplementationManager;
+
+    return { implementationManager, deployer };
+}

--- a/tests/ImplementationManager/ImplementationManager.ts
+++ b/tests/ImplementationManager/ImplementationManager.ts
@@ -122,7 +122,20 @@ describe("ImplementationManager Contract", function () {
         .to.be.revertedWithCustomError(implementationManager, "NotAuthorized");
     });
 
-    // Similar tests for adding implementations
+    it("Should only allow UPDATER_ROLE to add an implementation", async function () {
+      const [_, otherAccount] = await ethers.getSigners();
+
+      const typeName = "TestType";
+      const version = 1;
+      const commitHash = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+
+      // First, add the contract type with the deployer (who has UPDATER_ROLE)
+      await implementationManager.addContractType(typeName);
+
+      // Attempt to add an implementation with a different account
+      await expect(implementationManager.connect(otherAccount).addImplementation(typeName, deployer.address, version, commitHash))
+        .to.be.revertedWithCustomError(implementationManager, "NotAuthorized");
+    });
   });
 
   describe("Boundary Conditions", function () {

--- a/tests/ImplementationManager/ImplementationManager.ts
+++ b/tests/ImplementationManager/ImplementationManager.ts
@@ -1,0 +1,172 @@
+// ImplementationManager.test.ts
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { deployImplementationManagerFixture } from "./ImplementationManager.fixture";
+import type { ImplementationManager } from "../../types";
+import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+
+describe("ImplementationManager Contract", function () {
+  let implementationManager: ImplementationManager;
+  let deployer: SignerWithAddress;
+  let mockImplementation: string;
+
+  beforeEach(async function () {
+    ({ implementationManager, deployer } = await deployImplementationManagerFixture());
+    mockImplementation = deployer.address;
+  });
+
+  const fixedCommitHash = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+  const typeName = "TestType";
+
+
+  describe("Contract Type Management", function () {
+    it("Should allow adding a new contract type", async function () {
+      const typeName = "TestType";
+      await expect(implementationManager.addContractType(typeName))
+        .to.emit(implementationManager, "ContractTypeAdded"); // Assuming such an event exists
+    });
+
+    it("Should revert when adding an existing contract type", async function () {
+      const typeName = "TestType";
+      await implementationManager.addContractType(typeName);
+      await expect(implementationManager.addContractType(typeName))
+        .to.be.revertedWithCustomError(implementationManager, "TypeAlreadyExists");
+    });
+  });
+
+  describe("Implementation Management", function () {
+    it("Should allow adding an implementation", async function () {
+      const typeName = "TestType";
+      const version = 1;
+
+      await implementationManager.addContractType(typeName);
+      await expect(implementationManager.addImplementation(typeName, mockImplementation, version, fixedCommitHash))
+        .to.emit(implementationManager, "ImplementationAdded"); // Assuming such an event exists
+    });
+
+    it("Should revert when adding an implementation for a non-existent contract type", async function () {
+      const typeName = "NonExistentType";
+      const version = 1;
+
+      await expect(implementationManager.addImplementation(typeName, mockImplementation, version, fixedCommitHash))
+        .to.be.revertedWithCustomError(implementationManager, "TypeDoesNotExist");
+    });
+
+    it("Should revert when adding an implementation with an existing version", async function () {
+      const version = 1;
+
+      await implementationManager.addContractType(typeName);
+      await implementationManager.addImplementation(typeName, mockImplementation, version, fixedCommitHash);
+
+      const newCommitHash = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+      await expect(implementationManager.addImplementation(typeName, mockImplementation, version, newCommitHash))
+        .to.be.revertedWithCustomError(implementationManager, "VersionExists");
+    });
+
+    it("Should revert when adding an implementation with an existing commit hash", async function () {
+      const version = 1;
+      const newVersion = 2;
+
+      await implementationManager.addContractType(typeName);
+      await implementationManager.addImplementation(typeName, mockImplementation, version, fixedCommitHash);
+
+      await expect(implementationManager.addImplementation(typeName, mockImplementation, newVersion, fixedCommitHash))
+        .to.be.revertedWithCustomError(implementationManager, "CommitExists");
+    });
+  });
+
+  describe("Implementation Retrieval", function () {
+    it("Should retrieve the latest implementation", async function () {
+      const typeName = "TestType";
+      const version = 1;
+
+      await implementationManager.addContractType(typeName);
+      await implementationManager.addImplementation(typeName, mockImplementation, version, fixedCommitHash);
+
+      const [implementationAddress] = await implementationManager.getLatestImplementation(typeName);
+      expect(implementationAddress).to.equal(mockImplementation);
+    });
+
+    it("Should revert when retrieving an implementation for a non-existent type", async function () {
+      await expect(implementationManager.getLatestImplementation("NonExistentType"))
+        .to.be.revertedWithCustomError(implementationManager, "TypeDoesNotExist");
+    });
+
+    it("Should return correct implementation for a specific version", async function () {
+      const version = 1;
+      const newVersion = 2;
+      const newCommitHash = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+      const newMockImplementation = "0x0000000000000000000000000000000000000002";
+
+      await implementationManager.addContractType(typeName);
+      await implementationManager.addImplementation(typeName, mockImplementation, version, fixedCommitHash);
+      await implementationManager.addImplementation(typeName, newMockImplementation, newVersion, newCommitHash);
+
+      const implementationAddress = await implementationManager.getImplementationByVersion(typeName, newVersion);
+      expect(implementationAddress).to.equal(newMockImplementation);
+    });
+
+    it("Should revert when retrieving an implementation for a non-existent version", async function () {
+      const nonExistentVersion = 999;
+
+      await implementationManager.addContractType(typeName);
+      await expect(implementationManager.getImplementationByVersion(typeName, nonExistentVersion))
+        .to.be.revertedWithCustomError(implementationManager, "VersionDoesNotExist");
+    });
+  });
+
+  describe("Role-Based Access Control Tests", function () {
+    it("Should only allow UPDATER_ROLE to add a contract type", async function () {
+      const [_, otherAccount] = await ethers.getSigners();
+      await expect(implementationManager.connect(otherAccount).addContractType("NewType"))
+        .to.be.revertedWithCustomError(implementationManager, "NotAuthorized");
+    });
+
+    // Similar tests for adding implementations
+  });
+
+  describe("Boundary Conditions", function () {
+    it("Should handle maximum version number correctly", async function () {
+      const maxVersion = 65535; // uint16 max value
+      await implementationManager.addContractType(typeName);
+      await expect(implementationManager.addImplementation(typeName, mockImplementation, maxVersion, fixedCommitHash))
+        .to.emit(implementationManager, "ImplementationAdded");
+    });
+
+    it("Should handle edge-case names for contract types", async function () {
+      const edgeCaseName = ""; // Empty string
+      await expect(implementationManager.addContractType(edgeCaseName))
+        .to.be.revertedWithCustomError(implementationManager, "InvalidTypeName"); // Assuming such a custom error
+    });
+    // Similar test for very long string and special characters
+  });
+
+  describe("State Consistency Checks", function () {
+    it("Should update state correctly after adding implementations", async function () {
+      const version = 1;
+      await implementationManager.addContractType(typeName);
+      await implementationManager.addImplementation(typeName, mockImplementation, version, fixedCommitHash);
+
+      const latestVersion = (await implementationManager.contractTypes(await implementationManager.getTypeHash(typeName))).latestVersion;
+      expect(latestVersion).to.equal(version);
+    });
+  });
+
+  describe("Invalid Inputs", function () {
+    it("Should revert when adding an implementation with an invalid address", async function () {
+      const invalidAddress = "0x0000000000000000000000000000000000000000"; // Zero address
+      await implementationManager.addContractType(typeName);
+      await expect(implementationManager.addImplementation(typeName, invalidAddress, 1, fixedCommitHash))
+        .to.be.revertedWithCustomError(implementationManager, "InvalidAddress");
+    });
+  });
+
+  describe("Revert on Empty Implementations Array", function () {
+    it("Should revert when retrieving implementation for an empty array", async function () {
+      await implementationManager.addContractType(typeName);
+      await expect(implementationManager.getLatestImplementation(typeName))
+        .to.be.revertedWithCustomError(implementationManager, "NoImplementations");
+    });
+  });
+  // Additional tests can be added as needed...
+});

--- a/tests/factory/Factory.fixture.ts
+++ b/tests/factory/Factory.fixture.ts
@@ -1,19 +1,24 @@
 import { ethers } from "hardhat";
-import type { MockFactory } from "../../types/contracts/factory/mock/MockFactory";
-import type { MockFactory__factory } from "../../types/factories/contracts/factory/mock/MockFactory__factory";
+import type { MockFactory, MockToken } from "../../types";
+import type { MockFactory__factory, MockToken__factory } from "../../types";
 
 export async function deployMockFactoryFixture() {
 
   // Contracts are deployed using the first signer/account by default
   const [deployer] = await ethers.getSigners();
 
-  const Factory = (await ethers.getContractFactory("MockFactory")) as MockFactory__factory;
-  const factory = await Factory.deploy("demoName", deployer.address) as MockFactory;
+  // Deploy the MockFactory
+  const Factory = (await ethers.getContractFactory("MockFactory", deployer)) as MockFactory__factory;
+  const factory = await Factory.deploy() as MockFactory;
 
+  // Deploy the MockToken
+  const Token = (await ethers.getContractFactory("MockToken", deployer)) as MockToken__factory;
+  const token = await Token.deploy() as MockToken;
 
-  const implementationAddress = await factory.getAddress(); // Replace with implementation address
+  // Initialize the MockToken with desired parameters
+  await token.initialize("MockToken", "MTK");
 
-  await factory.updateImplementation(implementationAddress);
+  const implementationAddress = await token.getAddress();
 
-  return { factory, deployer, implementationAddress };
+  return { factory, token, deployer, implementationAddress };
 }

--- a/tests/factory/Factory.ts
+++ b/tests/factory/Factory.ts
@@ -1,33 +1,86 @@
 import { expect } from "chai";
+import { ethers } from "hardhat";
 import { deployMockFactoryFixture } from "./Factory.fixture";
+import type { MockFactory, MockToken } from "../../types";
+import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
-describe("Factory Contract", function () {
-    beforeEach(async function () {
-        const { factory, deployer, implementationAddress } = await deployMockFactoryFixture();
-        this.factory = factory;
-        this.deployer = deployer;
-        this.implementationAddress = implementationAddress;
+describe("MockFactory Contract", function () {
+  let factory: MockFactory;
+  let token: MockToken;
+  let deployer: SignerWithAddress;
+  let implementationAddress: string;
+
+  beforeEach(async function () {
+    ({ factory, token, deployer, implementationAddress } = await deployMockFactoryFixture());
+  });
+
+  const fixedSalt = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+
+  describe("Clone Creation", function () {
+    it("Should create a clone of the MockToken", async function () {
+      await expect(factory.clone(fixedSalt, implementationAddress)).to.emit(factory, "CloneCreated");
     });
 
-    describe("Deployment", function () {
-        it("Should set the right implementation address", async function () {
-            expect(await this.factory.implementation()).to.equal(this.implementationAddress);
-        });
+    it("Should emit Clone Created event with correct arguments", async function () {
+      const tx = await factory.clone(fixedSalt, implementationAddress);
+      const receipt = await tx.wait();
 
-        it("Should assign the deployer as the admin", async function () {
-            expect(await this.factory.hasRole(await this.factory.DEFAULT_ADMIN_ROLE(), this.deployer.address)).to.be.true;
-        });
+      const event = receipt?.logs?.[0];
+
+      expect(event?.args?.[1]).to.equal(implementationAddress);
+      expect(event?.args?.[2]).to.equal(fixedSalt);
+
+    })
+  });
+
+  describe("Clone Initialization", function () {
+    it("Should initialize the cloned MockToken", async function () {
+      const initData = token.interface.encodeFunctionData("initialize", ["ClonedToken", "CTK"]);
+      const tx = await factory.clone(fixedSalt, implementationAddress);
+      const receipt = await tx.wait();
+
+      const event = receipt?.logs?.[0];
+
+      const cloneAddress = event?.args?.[0];
+
+      await expect(factory.initClone(cloneAddress, initData))
+        .to.emit(factory, "CloneInitialized")
+        .withArgs(cloneAddress, initData);
+
+      const clonedToken = await ethers.getContractAt("MockToken", cloneAddress) as MockToken;
+      expect(await clonedToken.name()).to.equal("ClonedToken");
+      expect(await clonedToken.symbol()).to.equal("CTK");
     });
+  });
 
-    describe("Implementation Update", function () {
-        it("Should update the implementation address", async function () {
-            const newImplementationAddress = this.deployer.address; // Replace with new implementation address
-            await expect(this.factory.updateImplementation(newImplementationAddress))
-                .to.emit(this.factory, "ImplementationStored")
-                .withArgs(newImplementationAddress);
-            expect(await this.factory.implementation()).to.equal(newImplementationAddress);
-        });
+  describe("Clone and Initialize in One Step", function () {
+    it("Should clone and initialize the MockToken in one transaction", async function () {
+      const initData = token.interface.encodeFunctionData("initialize", ["OneStepToken", "OST"]);
+      const tx = await factory.cloneAndInitialize(fixedSalt, implementationAddress, initData);
+      const receipt = await tx.wait();
+
+      const event = receipt?.logs?.[0];
+
+      const cloneAddress = event?.args?.[0];
+
+      const clonedToken = await ethers.getContractAt("MockToken", cloneAddress) as MockToken;
+      expect(await clonedToken.name()).to.equal("OneStepToken");
+      expect(await clonedToken.symbol()).to.equal("OST");
     });
+  });
 
-    // Add more test cases as needed...
+  describe.only("Predict Clone Address", function () {
+    it("Should predict the address of a clone correctly", async function () {
+      const predictedAddress = await factory.predictCloneAddress(fixedSalt, implementationAddress);
+      const tx = await factory.clone(fixedSalt, implementationAddress);
+      const receipt = await tx.wait();
+
+      const event = receipt?.logs?.[0];
+
+      const cloneAddress = event?.args?.[0];
+
+      expect(predictedAddress).to.equal(cloneAddress);
+    });
+  });
+
 });

--- a/tests/factory/Factory.ts
+++ b/tests/factory/Factory.ts
@@ -2,16 +2,14 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { deployMockFactoryFixture } from "./Factory.fixture";
 import type { MockFactory, MockToken } from "../../types";
-import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
 describe("MockFactory Contract", function () {
   let factory: MockFactory;
   let token: MockToken;
-  let deployer: SignerWithAddress;
   let implementationAddress: string;
 
   beforeEach(async function () {
-    ({ factory, token, deployer, implementationAddress } = await deployMockFactoryFixture());
+    ({ factory, token, implementationAddress } = await deployMockFactoryFixture());
   });
 
   const fixedSalt = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
@@ -69,7 +67,7 @@ describe("MockFactory Contract", function () {
     });
   });
 
-  describe.only("Predict Clone Address", function () {
+  describe("Predict Clone Address", function () {
     it("Should predict the address of a clone correctly", async function () {
       const predictedAddress = await factory.predictCloneAddress(fixedSalt, implementationAddress);
       const tx = await factory.clone(fixedSalt, implementationAddress);


### PR DESCRIPTION
I separated the factory contract and implementation management so we could more easily test each one. 

Implementation management can now handle any number of implementations. 

Next up, need to add  a layer to manage specifically Governor, Token, Timelock deployments. 